### PR TITLE
add support for notify-send with variable number of options in json notification section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+tags
+
+# Created by https://www.toptal.com/developers/gitignore/api/vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/vim

--- a/myrmidon.sh
+++ b/myrmidon.sh
@@ -26,3 +26,13 @@ if [[ $confirm == "true" ]]; then
 else
   eval "\"$task_command\" > /dev/null &"
 fi
+
+notification=$(echo $task | jq ".notification")
+if [ ! -z "$notification" ]
+then
+    # extended notification text
+    notification_command=$(echo $notification | jq -r '. | "notify-send \"\(.text)\" " ')
+    # add options 
+    notification_command=${notification_command}$(echo $notification | jq --raw-output ' del( . .text ) ' | sed '1d;$d' | sed 's/[", ]//g;s/:/=/;s/^/--/' | xargs)
+  eval "$notification_command > /dev/null &"
+fi

--- a/myrmidon.sh
+++ b/myrmidon.sh
@@ -28,11 +28,11 @@ else
 fi
 
 notification=$(echo $task | jq ".notification")
-if [ ! -z "$notification" ]
+if [ ! "$notification" == 'null' ]
 then
     # extended notification text
     notification_command=$(echo $notification | jq -r '. | "notify-send \"\(.text)\" " ')
     # add options 
     notification_command=${notification_command}$(echo $notification | jq --raw-output ' del( . .text ) ' | sed '1d;$d' | sed 's/[", ]//g;s/:/=/;s/^/--/' | xargs)
-  eval "$notification_command > /dev/null &"
+    eval "$notification_command > /dev/null &"
 fi

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,44 @@ For example, in `i3`:
 ```
 bindsym $mod+p exec --no-startup-id ~/bin/myrmidon.sh
 ```
+### Add notificatoin
+
+This is an attempt to integrate notification proposed in issue [#8](https://github.com/moustacheful/myrmidon/issues/8)
+
+This solution depends on [notify-send](https://manpages.ubuntu.com/manpages/xenial/man1/notify-send.1.html) and gnome icons.
+
+```json
+[
+  {
+    "name": "Area screenshot",
+    "command": "gnome-screenshot -a",
+    "notification": {
+        "text":"Area screenshot",
+        "icon":"xscreensaver",
+        "urgency":"low"
+          }
+  }
+]
+```
+
+One could add all options accepted by notify-send, just take care that the key must be **exactly** the long option.
+```
+$ notify-send --help
+Usage:
+  notify-send [OPTION…] <SUMMARY> [BODY] - create a notification
+
+Help Options:
+  -?, --help                        Show help options
+
+Application Options:
+  -u, --urgency=LEVEL               Specifies the urgency level (low, normal, critical).
+  -t, --expire-time=TIME            Specifies the timeout in milliseconds at which to expire the notification.
+  -a, --app-name=APP_NAME           Specifies the app name for the icon
+  -i, --icon=ICON[,ICON...]         Specifies an icon filename or stock icon to display.
+  -c, --category=TYPE[,TYPE...]     Specifies the notification category.
+  -h, --hint=TYPE:NAME:VALUE        Specifies basic extra data to pass. Valid types are int, double, string and byte.
+  -v, --version                     Version of the package.
+```
 
 ## Multiple config files
 


### PR DESCRIPTION


This add support for notification via notify-send. See [Suggestion : add notification · Issue #8 · moustacheful/myrmidon](https://github.com/moustacheful/myrmidon/issues/8)